### PR TITLE
add image2image support

### DIFF
--- a/src/rp_schemas.py
+++ b/src/rp_schemas.py
@@ -67,6 +67,16 @@ INPUT_SCHEMA = {
         'required': False,
         'default': 1
     },
+    'strength': {
+        'type': float,
+        'required': False,
+        'default': 0.2
+    },
+    'init_image': {
+        'type': str,
+        'required': False,
+        'default': ""
+    },
 
     # Included for backwards compatibility
     'batch_size': {


### PR DESCRIPTION
Added image2image support to the kandinsky2 worker. 

I made use of components as per [huggingface documentation](https://huggingface.co/docs/diffusers/v0.17.1/en/api/diffusion_pipeline#diffusers.DiffusionPipeline.components) to run different pipelines with the same weights and configurations to not have to re-allocate memory. 

